### PR TITLE
chore: Replace `font: false` with privacy plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,6 @@ theme:
     accent: blue
   icon:
     repo: fontawesome/brands/github
-  font: false
   features:
     - navigation.instant
     - navigation.tracking
@@ -46,6 +45,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - privacy
 
 extra:
   social:


### PR DESCRIPTION
This PR replaces the `font: false` configuration with the (relatively) new [privacy plugin](https://squidfunk.github.io/mkdocs-material/plugins/privacy/)